### PR TITLE
Tag and release workflows

### DIFF
--- a/.github/workflows/releases.yml
+++ b/.github/workflows/releases.yml
@@ -5,19 +5,18 @@ name: releases
 
 
 # github release UI options
-# - Creting a new release from an existing tag:
-#    - Triggers published + (pre)released + (maybe/sometimes) created
+# - Creating a new release from an existing tag:
+#    - Triggers published + (pre)released + (if not created as draft) created
 # - creating a new release without a tag
-#    - Triggers published + push.tag + (pre)released.
-#    - Did not get a creaed event, as it was originally created as a draft.
+#    - Triggers published + push.tag + (pre)released. + (if not created as draft) created
 
 
 
 # Release types / actions:
   # - published - when a draft release is published.
-  # - unpublished - Not sure how to trigger this from the github UI
-  # - created - This appears to be triggered sometimes from the ui but not always - release, created and published from same commit at the same time?
-  # - edited - When release body/name is edited? 
+  # - unpublished - When a published release is turned back into a draft(api only?) - this then will not fire as not triggered by draft workflows.
+  # - created - Draft events do not trigger, so only occurs if straight to published.
+  # - edited - When the release is modified - only appears to be text changes not the tag!
   # - deleted - delete button.
   # - prereleased - when publshed && is marked as a pre-release
   # - released - when published && is not marked as a pre-release

--- a/.github/workflows/releases.yml
+++ b/.github/workflows/releases.yml
@@ -6,13 +6,14 @@ name: releases
 
 # Release types / actions:
   # - published - when a draft release is published.
-  # - unpublished
-  # - created
+  # - unpublished - Not sure how to trigger this from the github UI
+  # - created - Not sure how to trigger this from teh github UI.
   # - edited - When release body/name is edited? 
-  # - deleted
+  # - deleted - delete button.
   # - prereleased - when publshed && is marked as a pre-release
   # - released - when published && is not marked as a pre-release
 
+# Force pushing a tag to a different commit does not re-trigger the release! - should have a on.push.tag which checks if tehre is an assocated release and if so does any extra objects?
 
 on:
   release:

--- a/.github/workflows/releases.yml
+++ b/.github/workflows/releases.yml
@@ -1,0 +1,37 @@
+# Workflow for releases
+name: releases
+
+# Handle release events - this workflow needs to be present in the tag beign applied?
+
+
+on:
+  release:
+    types: 
+      - published
+      - unpublished
+      - created
+      - edited
+      - deleted
+      - prereleased
+      - released
+
+
+jobs:
+  do_release:
+    runs-on: ubuntu-18.04
+
+    steps:
+      - uses: actions/checkout@v2
+
+      - name: Dump GitHub context
+        env:
+          GITHUB_CONTEXT: ${{ toJson(github) }}
+        run: echo "$GITHUB_CONTEXT"
+
+      - name: Configure
+        run: cmake . -B build
+        shell: bash
+
+      # - name: build
+      #   run: cmake --build . --target all 
+      #   working-directory: build

--- a/.github/workflows/releases.yml
+++ b/.github/workflows/releases.yml
@@ -10,8 +10,6 @@ name: releases
 # - creating a new release without a tag
 #    - Triggers published + push.tag + (pre)released. + (if not created as draft) created
 
-
-
 # Release types / actions:
   # - published - when a draft release is published.
   # - unpublished - When a published release is turned back into a draft(api only?) - this then will not fire as not triggered by draft workflows.
@@ -21,18 +19,18 @@ name: releases
   # - prereleased - when publshed && is marked as a pre-release
   # - released - when published && is not marked as a pre-release
 
-# Force pushing a tag to a different commit does not re-trigger the release! - should have a on.push.tag which checks if tehre is an assocated release and if so does any extra objects?
+# Force pushing a tag to a different commit does not re-trigger the release! - should have a on.push.tag which checks if there is an assocated release and if so does any extra objects?
 
 on:
   release:
     types: 
       - published
-      - unpublished
-      - created
-      - edited
-      - deleted
-      - prereleased
-      - released
+      # - unpublished
+      # - created
+      # - edited
+      # - deleted
+      # - prereleased
+      # - released
 
 
 jobs:
@@ -51,6 +49,35 @@ jobs:
         run: cmake . -B build
         shell: bash
 
-      # - name: build
-      #   run: cmake --build . --target all 
-      #   working-directory: build
+      - name: build
+        run: cmake --build . --target all 
+        working-directory: build
+
+      - name: create artifact
+        run: zip -r build.zip build
+
+      - name: upload
+        if: success()
+        uses: actions/upload-release-asset@v1
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          upload_url: ${{ github.event.release.upload_url }}
+          asset_path: ./build.zip
+          asset_name: build.zip
+          asset_content_type: application/zip
+
+
+      # If the release CI works, mark it as a
+      - name: Mark as release
+        if: success() && github.event.release.prerelease
+        run: |
+          echo "Mark this as a not pre-release automatically?"
+          echo "url: ${{ github.event.release.url }}"
+          curl --request POST \
+          --url ${{ github.event.release.url }} \
+          --header 'authorization: Bearer ${{ secrets.GITHUB_TOKEN }}' \
+          --header 'content-type: application/json' \
+          --data '{
+            "prerelease": true,
+          }' | jq --raw-output -e '.id'

--- a/.github/workflows/releases.yml
+++ b/.github/workflows/releases.yml
@@ -4,6 +4,16 @@ name: releases
 # Handle release events - this workflow needs to be present in the tag beign applied?
 
 
+# Release types / actions:
+  # - published - when a draft release is published.
+  # - unpublished
+  # - created
+  # - edited - When release body/name is edited? 
+  # - deleted
+  # - prereleased - when publshed && is marked as a pre-release
+  # - released - when published && is not marked as a pre-release
+
+
 on:
   release:
     types: 

--- a/.github/workflows/releases.yml
+++ b/.github/workflows/releases.yml
@@ -4,10 +4,19 @@ name: releases
 # Handle release events - this workflow needs to be present in the tag beign applied?
 
 
+# github release UI options
+# - Creting a new release from an existing tag:
+#    - Triggers published + (pre)released + (maybe/sometimes) created
+# - creating a new release without a tag
+#    - Triggers published + push.tag + (pre)released.
+#    - Did not get a creaed event, as it was originally created as a draft.
+
+
+
 # Release types / actions:
   # - published - when a draft release is published.
   # - unpublished - Not sure how to trigger this from the github UI
-  # - created - Not sure how to trigger this from teh github UI.
+  # - created - This appears to be triggered sometimes from the ui but not always - release, created and published from same commit at the same time?
   # - edited - When release body/name is edited? 
   # - deleted - delete button.
   # - prereleased - when publshed && is marked as a pre-release

--- a/.github/workflows/tag.yml
+++ b/.github/workflows/tag.yml
@@ -7,6 +7,7 @@ name: tag
 
 
 # force pushes to tags do not - re-trigger any release event, but they do re-trigger the push.tag
+# If the release is created from an un-tagged commit, there is no guarantee that this (the push.tag action) has completed or been issued prior to the release action. Probably best to activate on both (although then may double-trigger?)
 
 on:
   push:

--- a/.github/workflows/tag.yml
+++ b/.github/workflows/tag.yml
@@ -6,6 +6,8 @@ name: tag
 # This could then potentially be checked on release creation.
 
 
+# force pushes to tags do not - re-trigger any release event, but they do re-trigger the push.tag
+
 on:
   push:
     tags:

--- a/.github/workflows/tag.yml
+++ b/.github/workflows/tag.yml
@@ -1,0 +1,32 @@
+# Workflow for tags and releases
+name: tag
+
+# Tagged commits by an approved author should trigger thorough builds - 
+# Possibly only tags which represent a version number?
+# This could then potentially be checked on release creation.
+
+
+on:
+  push:
+    tags:
+      - 'v[0-9]+.[0-9]+.[0-9]+' 
+
+jobs:
+  do_tag:
+    runs-on: ubuntu-18.04
+
+    steps:
+      - uses: actions/checkout@v2
+
+      - name: Dump GitHub context
+        env:
+          GITHUB_CONTEXT: ${{ toJson(github) }}
+        run: echo "$GITHUB_CONTEXT"
+
+      - name: Configure
+        run: cmake . -B build
+        shell: bash
+
+      # - name: build
+      #   run: cmake --build . --target all 
+      #   working-directory: build


### PR DESCRIPTION
Adds 2 workflows:

+ `tag.yml`
    + On push of a new tag, runs ci, creates a zip, creates a release, attaches zip to release
+ `releases.yml`
    + On user-creation of a new release, runs ci, creates zip, attaches zip to release, marks release as not pre-release.

Unsure which is preffered (leaning towards slightly less automation) 